### PR TITLE
chore: add Browserslist docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # carbon
 Core elements of Sparkbox projects
+
+## Browserslist
+The `.browserslistrc` file is a list of browsers that front-end tools will target. Currently, the Carbon tools using `.browserslistrc` are:
+* Autoprefixer
+* Babel
+
+You can test your Browserslist query configurations via [this tool](http://browserl.ist/).


### PR DESCRIPTION
Adds some basic documentation for the `.browserslistrc` file.